### PR TITLE
go 1.17 in the dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13
+FROM golang:1.17
 
 WORKDIR /app
 COPY . ./


### PR DESCRIPTION
Oops, Dockerfile was based on `golang:1.13` when that should have been `golang:1.17`